### PR TITLE
Added support for removal of wrapper parent node

### DIFF
--- a/src/client/components/Editor.js
+++ b/src/client/components/Editor.js
@@ -266,21 +266,21 @@ class Editor extends React.Component {
         }
 
         const shouldParentBeRemoved = (node, originalParent) => {
+            // Setup the data necessary for the check
+            const freedNodeNewParentId = node.parent()?.id();
             const opId = originalParent.id();
             const opName = originalParent.data().name;
             const opDescription = originalParent.data().description;
             const opDegrees = originalParent.totalDegree();
             const opChildren = originalParent.children().length;
 
-            const freedNodeNewParentId = node.parent()?.id();
-
-            // Leaving for future debugging purposes
-            //console.log(`Old parent: ${opId}, new parent: ${freedNodeNewParentId}, name: ${opName}, desc: ${opDescription}, deg: ${opDegrees}, children: ${opChildren}`);
-
             const noMultipleNodeDependecies = opChildren < 2;
             const hasNoEdges = !opDegrees;
             const hasNoData = !opName && !opDescription;
             const nodeMovedToDifferentParent = opId != freedNodeNewParentId;
+
+            // Leaving for future debugging purposes
+            //console.log(`Old parent: ${opId}, new parent: ${freedNodeNewParentId}, name: ${opName}, desc: ${opDescription}, deg: ${opDegrees}, children: ${opChildren}`);
 
             return nodeMovedToDifferentParent
                 && hasNoData
@@ -310,6 +310,8 @@ class Editor extends React.Component {
             if (originalParent.empty()) {
                 return;
             }
+
+            const opId = originalParent.id();
 
             // Remove prior compound parent if necessary
             const node = evt.target;

--- a/src/client/components/Editor.js
+++ b/src/client/components/Editor.js
@@ -249,8 +249,43 @@ class Editor extends React.Component {
             // only select one node at a time
             this.setState({
                 selected: cyto.collection().union(node),
-                selectedType: 'node'
+                selectedType: 'node',
+                selectedNodeOriginalParent: node.parent(),
             });
+        }
+
+        const releaseChildrenFromParent = (node) => {
+            // Children of node to be deleted are moved to the parent, if one exists. This allows for deletion of
+            // parent node without losing children.
+            node.children().move({parent: node.parent().id() ?? null});
+        }
+
+        const deleteGraphEntity = (type, id) => {
+            const selector = `${this.state.selectedType}[id = "${id}"]`;
+            this.state.cytoscape.remove(selector);
+        }
+
+        const shouldParentBeRemoved = (node, originalParent) => {
+            const opId = originalParent.id();
+            const opName = originalParent.data().name;
+            const opDescription = originalParent.data().description;
+            const opDegrees = originalParent.totalDegree();
+            const opChildren = originalParent.children().length;
+
+            const freedNodeNewParentId = node.parent()?.id();
+
+            // Leaving for future debugging purposes
+            //console.log(`Old parent: ${opId}, new parent: ${freedNodeNewParentId}, name: ${opName}, desc: ${opDescription}, deg: ${opDegrees}, children: ${opChildren}`);
+
+            const noMultipleNodeDependecies = opChildren < 2;
+            const hasNoEdges = !opDegrees;
+            const hasNoData = !opName && !opDescription;
+            const nodeMovedToDifferentParent = opId != freedNodeNewParentId;
+
+            return nodeMovedToDifferentParent
+                && hasNoData
+                && hasNoEdges
+                && noMultipleNodeDependecies;
         }
 
         // Click node to select
@@ -258,6 +293,35 @@ class Editor extends React.Component {
             const node = evt.target;
             selectNode(node);
             this.closeSidebar();
+        });
+
+        // When an element is grabbed directly
+        cyto.on('grabon', 'node', (evt) => {
+            const node = evt.target;
+            const originalParent = node.parent();
+            this.setState({
+                grabbedNodeOriginalParent: originalParent.first(),
+            });
+        });
+
+        // When an element is freed directly
+        cyto.on('freeon', 'node', (evt) => {
+            const originalParent = this.state.grabbedNodeOriginalParent;
+            if (originalParent.empty()) {
+                return;
+            }
+
+            // Remove prior compound parent if necessary
+            const node = evt.target;
+            if (shouldParentBeRemoved(node, originalParent)) {
+                releaseChildrenFromParent(originalParent);
+                deleteGraphEntity('node', originalParent.id())
+            }
+
+            // Set the state back to null
+            this.setState({
+                grabbedNodeOriginalParent: null,
+            });
         });
 
         // Click edge to select
@@ -269,7 +333,8 @@ class Editor extends React.Component {
             // only select one edge at a time
             this.setState({
                 selected: cyto.collection().union(edge),
-                selectedType: 'edge'
+                selectedType: 'edge',
+                selectedNodeOriginalParent: null,
             });
         });
 
@@ -324,14 +389,10 @@ class Editor extends React.Component {
             // Delete a node
             if ((evt.key === 'Delete') && (!this.state.modalOpen) && (!this.state.detailNode)) {
                 const node = this.state.selected.first();
-
-                // Children of node to be deleted are moved to the parent, if one exists. This allows for deletion of
-                // parent node without losing children.
-                node.children().move({parent: node.parent().id() ?? null});
+                releaseChildrenFromParent(node);
 
                 const id = node.data().id;
-                const selector = `${this.state.selectedType}[id = "${id}"]`;
-                this.state.cytoscape.remove(selector);
+                deleteGraphEntity(this.state.selectedType, id);
                 handleDiv.hidden = true;
             }
 

--- a/src/client/components/Editor.js
+++ b/src/client/components/Editor.js
@@ -261,7 +261,7 @@ class Editor extends React.Component {
         }
 
         const deleteGraphEntity = (type, id) => {
-            const selector = `${this.state.selectedType}[id = "${id}"]`;
+            const selector = `${type}[id = "${id}"]`;
             this.state.cytoscape.remove(selector);
         }
 
@@ -280,7 +280,7 @@ class Editor extends React.Component {
             const nodeMovedToDifferentParent = opId != freedNodeNewParentId;
 
             // Leaving for future debugging purposes
-            //console.log(`Old parent: ${opId}, new parent: ${freedNodeNewParentId}, name: ${opName}, desc: ${opDescription}, deg: ${opDegrees}, children: ${opChildren}`);
+            // console.log(`Old parent: ${opId}, new parent: ${freedNodeNewParentId}, name: ${opName}, desc: ${opDescription}, deg: ${opDegrees}, children: ${opChildren}`);
 
             return nodeMovedToDifferentParent
                 && hasNoData
@@ -317,7 +317,7 @@ class Editor extends React.Component {
             const node = evt.target;
             if (shouldParentBeRemoved(node, originalParent)) {
                 releaseChildrenFromParent(originalParent);
-                deleteGraphEntity('node', originalParent.id())
+                deleteGraphEntity('node', opId)
             }
 
             // Set the state back to null


### PR DESCRIPTION
When dragging a node outside of a wrapper node (a node that surrounds one or more nodes), Cytoscape doesn't delete the wrapper. My change checks to make sure the following is true before deleting it after a node is dragged out and released from the cursor

* The node has no set data by the user.
* There are no incoming or outgoing edges from the wrapper.
* The wrapper is only wrapping around a single node.

I've done plenty of testing with new graphs and while I am fairly confident that this works, I would appreciate the extra testing.

Please go ahead and merge it if you would like this for the demo. Otherwise, feel free to keep it as a branch/PR until you're ready to merge it.